### PR TITLE
Stop deadlocking during tag pushes from ID to TJ

### DIFF
--- a/lib/identity_tijuana.rb
+++ b/lib/identity_tijuana.rb
@@ -49,7 +49,7 @@ module IdentityTijuana
 
   def self.push(sync_id, member_ids, external_system_params)
     begin
-      members = Member.where(id: member_ids).with_email
+      members = Member.where(id: member_ids).with_email.order(:id)
       yield members, nil
     rescue => e
       raise e
@@ -58,7 +58,7 @@ module IdentityTijuana
 
   def self.push_in_batches(sync_id, members, external_system_params)
     begin
-      members.in_batches(of: Settings.tijuana.push_batch_amount).each_with_index do |batch_members, batch_index|
+      members.each_slice(Settings.tijuana.push_batch_amount).with_index do |batch_members, batch_index|
         tag = JSON.parse(external_system_params)['tag']
         rows = ActiveModel::Serializer::CollectionSerializer.new(
           batch_members,


### PR DESCRIPTION
This change should prevent deadlocking from occurring in the TJ database during contention between simultaneous tag list pushes from ID to TJ.

It works by sorting the members to be updated by their ID. Accessing resources in an identical order is the sovereign cure for deadlocking.

Because the in_batches method doesn't play nicely with ordered lists, the change dispenses with that method altogether and replaces it with each_slice on the member list instead.