### PR TITLE
Capture import count on tag pushes from ID to TJ

### DIFF
--- a/lib/identity_tijuana.rb
+++ b/lib/identity_tijuana.rb
@@ -66,9 +66,7 @@ module IdentityTijuana
         ).as_json.to_a.map{|member| member[:email]}
         tijuana = API.new
         tijuana.tag_emails(tag, rows)
-
-        #TODO return write results here
-        yield batch_index, 0
+        yield batch_index, rows.count
       end
     rescue => e
       raise e


### PR DESCRIPTION
This change will ensure that the import count (number successfully processed) is captured when a tag list is pushed from ID to TJ. Currently it's always zero.