### PR TITLE
Remove support for syncing member custom fields and TJ tags

### DIFF
--- a/lib/identity_tijuana.rb
+++ b/lib/identity_tijuana.rb
@@ -108,11 +108,6 @@ module IdentityTijuana
         WHERE updated_at > '#{last_updated_at}'
         AND updated_at <= '#{users_dependent_data_cutoff}'
         UNION
-        SELECT distinct member_id
-        FROM custom_fields
-        WHERE updated_at > '#{last_updated_at}'
-        AND updated_at <= '#{users_dependent_data_cutoff}'
-        UNION
         SELECT DISTINCT member_id
         FROM member_subscriptions
         WHERE updated_at > '#{last_updated_at}'

--- a/spec/lib/identity_tijuana_pull_spec.rb
+++ b/spec/lib/identity_tijuana_pull_spec.rb
@@ -389,68 +389,6 @@ describe IdentityTijuana do
           expect(m.updated_at).to eq(id_updated_at)
         end
       end
-      context 'custom field flags' do
-        before(:each) do
-          @deceased_custom_field_key = FactoryBot.create(:custom_field_key, name: 'deceased')
-          @rts_custom_field_key = FactoryBot.create(:custom_field_key, name: 'rts')
-          @deceased_tag = FactoryBot.create(:tijuana_tag, name: 'deceased')
-          @rts_tag = FactoryBot.create(:tijuana_tag, name: 'rts')
-        end
-        it 'sets deceased and RTS flags in Identity if the most recent change was in Tijuana' do
-          m = FactoryBot.create(:member)
-          u = FactoryBot.create(:tijuana_user, email: m.email)
-          FactoryBot.create(:tijuana_tagging, taggable_id: u.id, taggable_type: 'User', tag: @deceased_tag)
-          FactoryBot.create(:tijuana_tagging, taggable_id: u.id, taggable_type: 'User', tag: @rts_tag)
-          IdentityTijuana.fetch_user_updates(@sync_id) {}
-          u.reload
-          m.reload
-          expect(u.taggings.find_by(tag: @deceased_tag)).not_to eq(nil)
-          expect(u.taggings.find_by(tag: @rts_tag)).not_to eq(nil)
-          expect(m.custom_fields.find_by(custom_field_key: @deceased_custom_field_key)&.data).to eq('true')
-          expect(m.custom_fields.find_by(custom_field_key: @rts_custom_field_key)&.data).to eq('true')
-        end
-        it 'unsets deceased and RTS flags in Identity if the most recent change was in Tijuana' do
-          m = FactoryBot.create(:member)
-          FactoryBot.create(:custom_field, member: m, custom_field_key: @deceased_custom_field_key, data: 'true')
-          FactoryBot.create(:custom_field, member: m, custom_field_key: @rts_custom_field_key, data: 'true')
-          u = FactoryBot.create(:tijuana_user, email: m.email)
-          IdentityTijuana.fetch_user_updates(@sync_id) {}
-          u.reload
-          m.reload
-          expect(u.taggings.find_by(tag: @deceased_tag)).to eq(nil)
-          expect(u.taggings.find_by(tag: @rts_tag)).to eq(nil)
-          expect(m.custom_fields.find_by(custom_field_key: @deceased_custom_field_key)&.data).to eq('false')
-          expect(m.custom_fields.find_by(custom_field_key: @rts_custom_field_key)&.data).to eq('false')
-        end
-        it 'sets deceased and RTS tags in Tijuana if the most recent change was in Identity' do
-          u = FactoryBot.create(:tijuana_user)
-          m = FactoryBot.create(:member, email: u.email)
-          FactoryBot.create(:custom_field, member: m, custom_field_key: @deceased_custom_field_key, data: 'true')
-          FactoryBot.create(:custom_field, member: m, custom_field_key: @rts_custom_field_key, data: 'true')
-          IdentityTijuana.fetch_user_updates(@sync_id) {}
-          u.reload
-          m.reload
-          expect(u.taggings.find_by(tag: @deceased_tag)).not_to eq(nil)
-          expect(u.taggings.find_by(tag: @rts_tag)).not_to eq(nil)
-          expect(m.custom_fields.find_by(custom_field_key: @deceased_custom_field_key)&.data).to eq('true')
-          expect(m.custom_fields.find_by(custom_field_key: @rts_custom_field_key)&.data).to eq('true')
-        end
-        it 'unsets deceased and RTS tags in Tijuana if the most recent change was in Identity' do
-          u = FactoryBot.create(:tijuana_user)
-          FactoryBot.create(:tijuana_tagging, taggable_id: u.id, taggable_type: 'User', tag: @deceased_tag)
-          FactoryBot.create(:tijuana_tagging, taggable_id: u.id, taggable_type: 'User', tag: @rts_tag)
-          m = FactoryBot.create(:member, email: u.email)
-          FactoryBot.create(:custom_field, member: m, custom_field_key: @deceased_custom_field_key, data: 'false')
-          FactoryBot.create(:custom_field, member: m, custom_field_key: @rts_custom_field_key, data: 'false')
-          IdentityTijuana.fetch_user_updates(@sync_id) {}
-          u.reload
-          m.reload
-          expect(u.taggings.find_by(tag: @deceased_tag)).to eq(nil)
-          expect(u.taggings.find_by(tag: @rts_tag)).to eq(nil)
-          expect(m.custom_fields.find_by(custom_field_key: @deceased_custom_field_key)&.data).to eq('false')
-          expect(m.custom_fields.find_by(custom_field_key: @rts_custom_field_key)&.data).to eq('false')
-        end
-      end
     end
 
     context 'when updating' do


### PR DESCRIPTION
The existing tags being sync'ed (`rts` and `deceased`) should now be set and searched for on Id only, so they don't need to be sync'ed to/from TJ. Further, now that the active flag is being set on members in Id via a lambda, the number of custom fields that aren't being sync'd has increased 100%, causing days worth of extra processing. So just remove this support, and build out anything further in the tasks repo.

This does not remove support for `syncid` tags or pushing lists from Id to a TJ tag.