### PR TITLE
Track modified donations via transactions

### DIFF
--- a/app/models/identity_tijuana/donation.rb
+++ b/app/models/identity_tijuana/donation.rb
@@ -72,7 +72,6 @@ module IdentityTijuana
             t.refund_of_id && t.successful ? [t.refund_of_id, t] : nil
           }.to_h
           transactions.each do |transaction|
-            next if transaction.refund_of_id
             next unless transaction.successful
 
             refund_transaction = refund_transactions[transaction.id]

--- a/app/models/identity_tijuana/donation.rb
+++ b/app/models/identity_tijuana/donation.rb
@@ -29,10 +29,10 @@ module IdentityTijuana
 
     def self.import(donation_id, sync_id)
       donation = Donation.find(donation_id)
-      donation.import(sync_id)
+      donation.import(sync_id, donation.transactions)
     end
 
-    def import(_sync_id)
+    def import(_sync_id, transactions)
       member = Member.find_by_external_id(:tijuana, user_id)
       if member.present?
         if member.ghosting_started?
@@ -68,9 +68,23 @@ module IdentityTijuana
               raise
             end
           end
-          refund_transactions = transactions.filter_map { |t|
-            t.refund_of_id && t.successful ? [t.refund_of_id, t] : nil
-          }.to_h
+
+          current_transaction_ids = Set.new
+          refund_transactions = {}
+
+          transactions.each do |t|
+            current_transaction_ids << t.id
+            refund_transactions[t.refund_of_id] = t if t.refund_of_id && t.successful
+          end
+
+          # If the refunded transaction is not present in the current batch,
+          # update the original donation's refunded_at timestamp.
+          refund_transactions.each do |refund_of_id, t|
+            if current_transaction_ids.exclude?(refund_of_id)
+              Donations::Donation.where(external_id: refund_of_id).update!(refunded_at: t.created_at)
+            end
+          end
+
           transactions.each do |transaction|
             next unless transaction.successful
 

--- a/app/models/identity_tijuana/transaction.rb
+++ b/app/models/identity_tijuana/transaction.rb
@@ -1,6 +1,12 @@
 module IdentityTijuana
   class Transaction < ReadWrite
     self.table_name = 'transactions'
-    belongs_to :donation, optional: true
+    belongs_to :donation, optional: false
+
+    scope :updated_transactions_all, ->(last_updated_at, last_id, exclude_from) {
+      where('updated_at > ? OR (updated_at = ? AND id > ?)',
+            last_updated_at, last_updated_at, last_id)
+        .where(updated_at: ...exclude_from)
+    }
   end
 end

--- a/spec/test_identity_app/app/models/donations/donation.rb
+++ b/spec/test_identity_app/app/models/donations/donation.rb
@@ -1,0 +1,87 @@
+# == Schema Information
+#
+# Table name: donations
+#
+# id               :integer    not null, primary key
+# member_action_id :integer
+# member_id        :integer
+# amount           :float
+# external_source  :text
+# created_at       :datetime
+# updated_at       :datetime
+# external_id      :text
+#
+class Donations::Donation < ApplicationRecord
+  belongs_to :member_action, optional: true
+  belongs_to :member
+  belongs_to :regular_donation, class_name: 'Donations::RegularDonation', optional: true
+
+  validates_uniqueness_of :amount, scope: %i[member_id created_at]
+
+  def self.card_mapping
+    {
+      'Visa' => 'vs',
+      'American Express' => 'ax',
+      'MasterCard' => 'mc',
+      'Discover' => 'ds',
+      'JCB' => 'ck',
+      'Diners Club' => 'ck',
+      'Unknown' => 'ck'
+    }
+  end
+
+  def self.nonce_used?(nonce)
+    Donation.where(nonce: nonce.to_s).count > 0
+  end
+
+  def self.log_quick_donate(member_id, amount, stripe_charge_id, nonce)
+    Donation.create!(member_id: member_id,
+                     amount: amount.to_f / 100,
+                     external_source: 'stripe:quick_donate',
+                     external_id: stripe_charge_id,
+                     nonce: nonce,
+                     medium: 'quick_donate')
+  end
+
+  def self.create_from_stripe_webhook!(event_data)
+    object = event_data['data']['object']
+    unless event_data['type'] == 'charge.succeeded' && object['metadata']['takecharge-tag-0']
+      return
+    end
+
+    member_hash = {
+      emails: [{ email: object['metadata']['email'] }],
+      external_ids: { controlshift: object['metadata']['takecharge-tag-3'].gsub('agra-member:', '').to_i }
+    }
+    member = UpsertMember.call(member_hash, ignore_name_change: Settings.options.ignore_name_change_for_donation)
+
+    Donations::Donation.create!(
+      member: member,
+      amount: object['amount'].to_i / 100,
+      external_source: object['metadata']['takecharge-tag-2'],
+      created_at: DateTime.strptime(object['created'].to_s, "%s"),
+      external_id: object['id'],
+      medium: 'stripe'
+    )
+  end
+
+  def self.upsert!(attrs)
+    # rubocop:disable Rails/SaveBang
+    if attrs[:external_id].present?
+      donation = Donations::Donation.find_or_create_by(attrs.slice(:medium, :external_id)) do |don|
+        don.assign_attributes(attrs.except(:medium, :external_id))
+      end
+    end
+
+    # Sometimes a save fails because the donation already exists but was missing an external_id (was not found)
+    # Use a find based on other attrs instead to try and find and merge the donation
+    if donation.blank? || donation.invalid?
+      donation = Donations::Donation.find_or_create_by(attrs.slice(:medium, :member_id, :amount, :created_at)) do |don|
+        don.assign_attributes(attrs.except(:medium, :member_id, :amount, :created_at))
+      end
+    end
+    donation.save!
+    # rubocop:enable Rails/SaveBang
+    return donation
+  end
+end

--- a/spec/test_identity_app/app/models/donations/failed_donation.rb
+++ b/spec/test_identity_app/app/models/donations/failed_donation.rb
@@ -1,0 +1,4 @@
+class Donations::FailedDonation < ApplicationRecord
+  belongs_to :member, optional: true
+  belongs_to :regular_donation, optional: true
+end

--- a/spec/test_identity_app/app/models/donations/regular_donation.rb
+++ b/spec/test_identity_app/app/models/donations/regular_donation.rb
@@ -1,0 +1,41 @@
+class Donations::RegularDonation < ApplicationRecord
+  belongs_to :member
+  belongs_to :member_action, optional: true
+  has_many :donations, class_name: 'Donations::Donation'
+  validates_presence_of :member_id
+
+  scope :active, -> { where("ended_at IS NULL OR ended_at > ?", Time.zone.now) }
+  scope :inactive, -> { where("ended_at <= ?", Time.zone.now) }
+
+  def self.upsert!(attrs)
+    rd = Donations::RegularDonation.find_or_initialize_by(attrs.slice(:medium, :external_id))
+
+    if rd.persisted? && attrs[:member_id] != rd.member_id
+      raise ArgumentError.new("member_id provided (#{attrs[:member_id]}) does not match existing regular donation record (#{rd.member_id})")
+    end
+
+    if rd.new_record?
+      rd.update!(attrs)
+    elsif attrs[:updated_at].present? && attrs[:updated_at] > rd.updated_at
+      rd.update!(attrs.except(:started_at, :initial_amount))
+    elsif attrs[:member_action_id].present? && rd.member_action_id.blank?
+      rd.update!(attrs.slice(:member_action_id))
+    end
+
+    return rd
+  end
+
+  def update_amount_last_changed_at
+    if updated_at_changed?
+      self.amount_last_changed_at = updated_at
+    else
+      self.amount_last_changed_at = DateTime.now
+    end
+  end
+  before_save :update_amount_last_changed_at, if: :current_amount_changed?
+
+  def update_initial_amount
+    self.initial_amount = current_amount if initial_amount.nil?
+  end
+  before_save :update_initial_amount
+end

--- a/spec/test_identity_app/spec/factories/tijuana/donation.rb
+++ b/spec/test_identity_app/spec/factories/tijuana/donation.rb
@@ -1,0 +1,7 @@
+module IdentityTijuana
+  FactoryBot.define do
+    factory :tijuana_donation, class: Donation do
+      # pass
+    end
+  end
+end

--- a/spec/test_identity_app/spec/factories/tijuana/transaction.rb
+++ b/spec/test_identity_app/spec/factories/tijuana/transaction.rb
@@ -1,0 +1,7 @@
+module IdentityTijuana
+  FactoryBot.define do
+    factory :tijuana_transaction, class: Transaction do
+      # pass
+    end
+  end
+end


### PR DESCRIPTION
### Summary
This PR changes the approach to tracking modified donations to ensure consistency and accuracy. Instead of relying on the donation's `updated_at`, we now track donation modifications via transactions updates.

### Key Changes
1. **Modified Donations**: Updates to donations are now driven by changes in related transactions, eliminating inconsistencies with the previous `updated_at` approach.
2. **Refund Handling**: Refunded transactions are now recorded as separate negative donations. Additionally, the original donation is marked with a `refunded_at` timestamp to keep record of the refund status.
3. **Test Coverage**: We’ve added the necessary tests for `fetch_donation_updates` to validate the donations sync behaviour.


For more info see the [Asana issue](https://app.asana.com/0/1206874604686569/1207999442908665).