### PR TITLE
Use select_all and bind ts arguments instead of raw SQL in 'fetch_user_updates'

### DIFF
--- a/app/lib/identity_tijuana/member_sync.rb
+++ b/app/lib/identity_tijuana/member_sync.rb
@@ -1,10 +1,9 @@
 module IdentityTijuana
   class MemberSync
     # Sync an ID member with TJ.
-    def self.export_member(member_id, sync_id)
+    def self.export_member(member, sync_id)
       sync_type = :unknown
       begin
-        member = Member.find(member_id)
         return if member.ghosting_started?
 
         ext_id = MemberExternalId.find_by(system: 'tijuana', member: member)


### PR DESCRIPTION
This PR updates the UNION query in `fetch_user_updates` to use ActiveRecord with bind parameters for SELECT statements, ensuring proper datetime handling by ActiveRecord.

We also implemented bulk loading of modified ID members to improve performance.

