### PR TITLE
Sync anon'ed members

### DIFF
--- a/app/lib/identity_tijuana/user_ghosting.rb
+++ b/app/lib/identity_tijuana/user_ghosting.rb
@@ -1,0 +1,229 @@
+module IdentityTijuana
+  class UserGhosting
+    def initialize(user_ids, reason)
+      @user_ids = user_ids
+      @reason = reason
+    end
+
+    def ghost_users
+      # We must never ghost member that has active recurring donations
+      recurring_donations = Donation.where(
+        user_id: @user_ids,
+        active: true,
+        cancelled_at: nil
+      ).where.not(
+        frequency: 'one-off'
+      ).where.not(
+        make_recurring_at: nil
+      )
+
+      if recurring_donations.any?
+        recurring_user_ids = recurring_donations.pluck(:user_id)
+
+        Rails.logger.error(
+          "Members [ids: #{recurring_user_ids.join(', ')}] " \
+          "with active recurring donations cannot be anonymised! " \
+          "Please notify Member Relations Team."
+        )
+
+        @user_ids -= recurring_user_ids
+      end
+
+      if @user_ids.empty?
+        Rails.logger.error "No member ids provided to anonymise."
+        return
+      end
+
+      tj_conn = IdentityTijuana::ReadWrite.connection
+      log_ids = log_anonymisation_started
+      @emails = get_emails(tj_conn)
+
+      begin
+        tj_conn.transaction do
+          anon_basic_info(tj_conn)
+          anon_call_outcomes(tj_conn)
+          anon_donations(tj_conn)
+          anon_facebook_users(tj_conn)
+          anon_merge_records(tj_conn)
+          anon_image_shares(tj_conn)
+          anon_petition_signatures(tj_conn)
+          anon_testimonials(tj_conn)
+          anon_user_emails(tj_conn)
+          anon_user_activity_events(tj_conn)
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        log_anonymisation_failed(log_ids, e.message, e)
+        Rails.logger.error "Anonymisation failed: #{e.message}"
+      end
+
+      log_anonymisation_finished(log_ids)
+    end
+
+    private
+
+    def get_emails(tj_conn)
+      res = tj_conn.select_all(<<~SQL.squish)
+        SELECT email
+        FROM users
+        WHERE id IN (#{@user_ids.join(',')});
+      SQL
+
+      res.pluck('email')
+    end
+
+    def log_anonymisation_started
+      log_ids = []
+
+      @user_ids.each do |user_id|
+        logged = AnonymisationLog.create!(
+          user_id: user_id,
+          anonymisation_reason: @reason,
+          status: 'started',
+          started_at: DateTime.current.utc,
+        )
+        log_ids << logged.id
+      end
+
+      log_ids
+    end
+
+    def log_anonymisation_finished(log_ids)
+      # rubocop:disable Rails/SkipsModelValidations
+      AnonymisationLog.where(id: log_ids)
+                      .update_all(
+                        finished_at: DateTime.current.utc,
+                        status: 'completed'
+                      )
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+
+    def log_anonymisation_failed(log_ids, error_msg, error_stack)
+      # rubocop:disable Rails/SkipsModelValidations
+      AnonymisationLog.where(id: log_ids)
+                      .update_all(
+                        finished_at: DateTime.current.utc,
+                        status: 'failed',
+                        message: error_msg,
+                        error_stack: error_stack
+                      )
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+
+    def anon_basic_info(tj_conn)
+      tj_conn.execute(<<~SQL.squish)
+        UPDATE users
+        SET email = concat(id, '@#{Settings.ghoster.email_domain}'),
+            first_name = null,
+            last_name = null,
+            mobile_number = null,
+            home_number = null,
+            street_address = null,
+            country_iso = null,
+            is_member = 0,
+            encrypted_password = null,
+            password_salt = null,
+            reset_password_token = null,
+            current_sign_in_ip = null,
+            last_sign_in_ip = null,
+            is_admin = 0,
+            postcode_id = null,
+            quick_donate_trigger_id = null,
+            facebook_id = null,
+            otp_secret_key = null,
+            do_not_call = 1,
+            active = 0,
+            do_not_sms = 1,
+            updated_at = CURRENT_TIMESTAMP
+          WHERE id IN (#{@user_ids.join(',')});
+      SQL
+    end
+
+    def anon_call_outcomes(tj_conn)
+      tj_conn.execute(<<~SQL.squish)
+        UPDATE call_outcomes
+        SET email = null,
+            donation_email = null,
+            payload = null,
+            dialed_number = null
+        WHERE user_id IN (#{@user_ids.join(',')});
+      SQL
+    end
+
+    def anon_donations(tj_conn)
+      tj_conn.execute(<<~SQL.squish)
+        UPDATE donations
+        SET name_on_card = null,
+            cheque_name = null,
+            identifier = null,
+            dynamic_attributes = null,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE user_id IN (#{@user_ids.join(',')});
+      SQL
+    end
+
+    def anon_facebook_users(tj_conn)
+      tj_conn.execute(<<~SQL.squish)
+        UPDATE facebook_users
+        SET facebook_id = null,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE user_id IN (#{@user_ids.join(',')});
+      SQL
+    end
+
+    def anon_merge_records(tj_conn)
+      sql = ActiveRecord::Base.sanitize_sql_array(["
+         UPDATE merge_records
+         SET join_id = NULL, `value` = NULL, updated_at = CURRENT_TIMESTAMP
+         WHERE `value` IN (?) OR join_id IN (?)
+         ", @emails, @emails])
+
+      tj_conn.execute(sql)
+    end
+
+    def anon_image_shares(tj_conn)
+      tj_conn.execute(<<~SQL.squish)
+        UPDATE image_shares
+        SET caption = '',
+            updated_at = CURRENT_TIMESTAMP
+        WHERE user_id IN (#{@user_ids.join(',')});
+      SQL
+    end
+
+    def anon_petition_signatures(tj_conn)
+      tj_conn.execute(<<~SQL.squish)
+        UPDATE petition_signatures
+        SET dynamic_attributes = null,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE user_id IN (#{@user_ids.join(',')});
+      SQL
+    end
+
+    def anon_testimonials(tj_conn)
+      tj_conn.execute(<<~SQL.squish)
+        UPDATE testimonials
+        SET facebook_user_id = null,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE user_id IN (#{@user_ids.join(',')});
+      SQL
+    end
+
+    def anon_user_activity_events(tj_conn)
+      tj_conn.execute(<<~SQL.squish)
+        UPDATE user_activity_events
+        SET public_stream_html = null,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE user_id IN (#{@user_ids.join(',')});
+      SQL
+    end
+
+    def anon_user_emails(tj_conn)
+      tj_conn.execute(<<~SQL.squish)
+        UPDATE user_emails
+        SET body = '',
+            `from` = '',
+            updated_at = CURRENT_TIMESTAMP
+        WHERE user_id IN (#{@user_ids.join(',')});
+      SQL
+    end
+  end
+end

--- a/app/models/identity_tijuana/anonymisation_log.rb
+++ b/app/models/identity_tijuana/anonymisation_log.rb
@@ -1,0 +1,6 @@
+module IdentityTijuana
+  class AnonymisationLog < ReadWrite
+    self.table_name = 'anonymisation_logs'
+    belongs_to :user
+  end
+end

--- a/app/models/identity_tijuana/call_outcome.rb
+++ b/app/models/identity_tijuana/call_outcome.rb
@@ -1,0 +1,7 @@
+module IdentityTijuana
+  class CallOutcome < ReadWrite
+    self.table_name = 'call_outcomes'
+
+    belongs_to :user
+  end
+end

--- a/app/models/identity_tijuana/facebook_user.rb
+++ b/app/models/identity_tijuana/facebook_user.rb
@@ -1,0 +1,7 @@
+module IdentityTijuana
+  class FacebookUser < ReadWrite
+    self.table_name = 'facebook_users'
+
+    validates :facebook_id, :user_id, presence: true
+  end
+end

--- a/app/models/identity_tijuana/image_share.rb
+++ b/app/models/identity_tijuana/image_share.rb
@@ -1,0 +1,7 @@
+module IdentityTijuana
+  class ImageShare < ReadWrite
+    self.table_name = 'image_shares'
+
+    belongs_to :user
+  end
+end

--- a/app/models/identity_tijuana/merge_record.rb
+++ b/app/models/identity_tijuana/merge_record.rb
@@ -1,0 +1,10 @@
+module IdentityTijuana
+  class MergeRecord < ReadWrite
+    self.table_name = 'merge_records'
+
+    validates :join_id, presence: true
+    validates :name, presence: true
+    validates :value, presence: true
+    validates :merge_id, presence: true
+  end
+end

--- a/app/models/identity_tijuana/petition_signature.rb
+++ b/app/models/identity_tijuana/petition_signature.rb
@@ -1,0 +1,7 @@
+module IdentityTijuana
+  class PetitionSignature < ReadWrite
+    self.table_name = 'petition_signatures'
+
+    belongs_to :user
+  end
+end

--- a/app/models/identity_tijuana/testimonial.rb
+++ b/app/models/identity_tijuana/testimonial.rb
@@ -1,0 +1,7 @@
+module IdentityTijuana
+  class Testimonial < ReadWrite
+    self.table_name = 'testimonials'
+
+    belongs_to :user
+  end
+end

--- a/app/models/identity_tijuana/user_email.rb
+++ b/app/models/identity_tijuana/user_email.rb
@@ -1,0 +1,7 @@
+module IdentityTijuana
+  class UserEmail < ReadWrite
+    self.table_name = 'user_emails'
+
+    belongs_to :user
+  end
+end

--- a/spec/app/lib/user_ghosting_spec.rb
+++ b/spec/app/lib/user_ghosting_spec.rb
@@ -1,0 +1,400 @@
+require 'rails_helper'
+
+describe IdentityTijuana::UserGhosting do
+  before(:each) do
+    allow(Settings).to(
+      receive_message_chain("tijuana.database_url") { ENV['TIJUANA_DATABASE_URL'] }
+    )
+    allow(Settings).to(
+      receive_message_chain("ghoster.email_domain") { 'anoned.non' }
+    )
+  end
+
+  context '#ghosting' do
+    let(:anon_domain) { Settings.ghoster.email_domain }
+    let(:enhanced_error) {
+      ->(attr, expected, actual) {
+        "Expected #{attr} to be #{expected}, but got #{actual}"
+      }
+    }
+
+    it 'should ghost user profile' do
+      user = FactoryBot.create(:tijuana_user_with_everything)
+      original_attributes = user.attributes.symbolize_keys
+
+      described_class.new([user.id], 'test-reason').ghost_users
+
+      user.reload
+
+      expect(user.email).to eq("#{user.id}@#{anon_domain}")
+
+      nils = [:first_name, :last_name, :mobile_number,
+              :home_number, :street_address, :country_iso,
+              :encrypted_password, :password_salt, :reset_password_token,
+              :postcode_id, :quick_donate_trigger_id, :facebook_id,
+              :otp_secret_key, :current_sign_in_ip, :last_sign_in_ip]
+
+      nils.each do |prop|
+        expect(user.send(prop)).to be(nil)
+      end
+
+      falsey = [:is_member, :is_admin, :active]
+
+      falsey.each do |prop|
+        expect(user.send(prop)).to eq(false)
+      end
+
+      truthy = [:do_not_call, :do_not_sms]
+
+      truthy.each do |prop|
+        expect(user.send(prop)).to eq(true)
+      end
+
+      # Ignoring :random because of potential precision changes
+      unchanged_attributes = original_attributes.except(*nils,
+                                                        *truthy,
+                                                        *falsey,
+                                                        :random,
+                                                        :email,
+                                                        :updated_at)
+
+      unchanged_attributes.each do |attr, value|
+        expect(user.send(attr)).to eq(value), enhanced_error.call(attr, value, user.send(attr))
+      end
+    end
+
+    it 'should ghost call_outcomes' do
+      u = FactoryBot.create(:tijuana_user)
+      co = FactoryBot.create(:call_outcome,
+                             email: u.email,
+                             user: u,
+                             payload: 'some PI data',
+                             dialed_number: '0411 123 123',
+                             disposition: 'No Answer',
+                             donation_email: 'different@donation-email.com',)
+      original_attributes = co.attributes.symbolize_keys
+
+      described_class.new([u.id], 'test-reason').ghost_users
+      co.reload
+
+      nils = [:email, :payload, :dialed_number, :donation_email]
+
+      nils.each do |prop|
+        expect(co.send(prop)).to eq(nil)
+      end
+
+      unchanged_attributes = original_attributes.except(*nils,
+                                                        :updated_at)
+
+      unchanged_attributes.each do |attr, value|
+        expect(co.send(attr)).to eq(value), enhanced_error.call(attr, value, co.send(attr))
+      end
+    end
+
+    it 'should ghost comments' do
+      skip 'comments may be abandoned - not to be ghosted'
+    end
+
+    it 'should ghost donations' do
+      u = FactoryBot.create(:tijuana_user)
+      d = IdentityTijuana::Donation.create!(
+        user: u,
+        page_id: 1,
+        email_id: 1,
+        content_module_id: 1,
+        active: true,
+        amount_in_cents: 1000,
+        payment_method: 'credit-card',
+        frequency: 'one-off',
+        name_on_card: u.first_name,
+        card_type: 'visa',
+        card_expiry_month: 01,
+        card_expiry_year: 2025,
+        card_last_four_digits: '7777',
+        cheque_name: u.first_name,
+        cheque_number: '123456789',
+        cheque_bank: 'Your Choice',
+        cheque_branch: 'Green',
+        cheque_bsb: '088-999',
+        cheque_account_number: '987654321',
+        cancel_reason: 'Just testing',
+
+        paypal_subscr_id: 100,
+        identifier: 'Joe Money Inc',
+        dynamic_attributes: 'Some PI or SI info',
+      )
+
+      original_attributes = d.attributes.symbolize_keys
+
+      described_class.new([u.id], 'test-reason').ghost_users
+
+      d.reload
+
+      nils = [:name_on_card, :cheque_name, :identifier, :dynamic_attributes]
+
+      nils.each do |prop|
+        expect(d.send(prop)).to eq(nil), enhanced_error.call(prop, nil, d.send(prop))
+      end
+
+      unchanged_attributes = original_attributes.except(*nils, :updated_at)
+
+      unchanged_attributes.each do |attr, value|
+        expect(d.send(attr)).to eq(value), enhanced_error.call(attr, value, d.send(attr))
+      end
+    end
+
+    it 'should ghost facebook_users' do
+      u = FactoryBot.create(:tijuana_user)
+      fbu = IdentityTijuana::FacebookUser.create!(
+        user_id: u.id,
+        facebook_id: 100,
+        app_id: 1,
+      )
+
+      original_attributes = fbu.attributes.symbolize_keys
+
+      described_class.new([u.id], 'test-reason').ghost_users
+
+      fbu.reload
+
+      nils = [:facebook_id]
+
+      nils.each do |prop|
+        expect(fbu.send(prop)).to eq(nil)
+      end
+
+      unchanged_attributes = original_attributes.except(*nils, :updated_at)
+
+      unchanged_attributes.each do |attr, value|
+        expect(fbu.send(attr)).to eq(value), enhanced_error.call(attr, value, fbu.send(attr))
+      end
+    end
+
+    it 'should ghost merge_records' do
+      u = FactoryBot.create(:tijuana_user)
+      mr = IdentityTijuana::MergeRecord.create!(
+        join_id: u.email,
+        merge_id: 1,
+        name: 'id',
+        value: '12345',
+      )
+
+      original_attributes = mr.attributes.symbolize_keys
+
+      described_class.new([u.id], 'test-reason').ghost_users
+
+      mr.reload
+
+      nils = [:join_id, :value]
+
+      nils.each do |prop|
+        expect(mr.send(prop)).to eq(nil)
+      end
+
+      unchanged_attributes = original_attributes.except(*nils, :updated_at)
+
+      unchanged_attributes.each do |attr, value|
+        expect(mr.send(attr)).to eq(value), enhanced_error.call(attr, value, mr.send(attr))
+      end
+    end
+
+    it 'should ghost image_shares' do
+      u = FactoryBot.create(:tijuana_user)
+      is = IdentityTijuana::ImageShare.create!(
+        user: u,
+        content_module_id: 1,
+        page_id: 1,
+        email_id: 1,
+        image_url: 'https://getup.org/image.jpg',
+        caption: 'Some PI or SI data is here',
+      )
+
+      original_attributes = is.attributes.symbolize_keys
+
+      described_class.new([u.id], 'test-reason').ghost_users
+
+      is.reload
+
+      empties = [:caption]
+
+      empties.each do |prop|
+        expect(is.send(prop)).to eq('')
+      end
+
+      unchanged_attributes = original_attributes.except(*empties, :updated_at)
+
+      unchanged_attributes.each do |attr, value|
+        expect(is.send(attr)).to eq(value), enhanced_error.call(attr, value, is.send(attr))
+      end
+    end
+
+    it 'should ghost petition_signatures' do
+      u = FactoryBot.create(:tijuana_user)
+      ps = IdentityTijuana::PetitionSignature.create!(
+        user: u,
+        content_module_id: 1,
+        page_id: 1,
+        email_id: 1,
+        dynamic_attributes: 'Some PI or SI data is here',
+      )
+
+      original_attributes = ps.attributes.symbolize_keys
+
+      described_class.new([u.id], 'test-reason').ghost_users
+
+      ps.reload
+
+      nils = [:dynamic_attributes]
+
+      nils.each do |prop|
+        expect(ps.send(prop)).to eq(nil)
+      end
+
+      unchanged_attributes = original_attributes.except(*nils, :updated_at)
+
+      unchanged_attributes.each do |attr, value|
+        expect(ps.send(attr)).to eq(value), enhanced_error.call(attr, value, ps.send(attr))
+      end
+    end
+
+    it 'should ghost testimonials' do
+      u = FactoryBot.create(:tijuana_user)
+      t = IdentityTijuana::Testimonial.create!(
+        user: u,
+        content_module_id: 1,
+        page_id: 1,
+        email_id: 1,
+        facebook_user_id: 123456789,
+      )
+
+      original_attributes = t.attributes.symbolize_keys
+
+      described_class.new([u.id], 'test-reason').ghost_users
+
+      t.reload
+
+      nils = [:facebook_user_id]
+
+      nils.each do |prop|
+        expect(t.send(prop)).to eq(nil)
+      end
+
+      unchanged_attributes = original_attributes.except(*nils, :updated_at)
+
+      unchanged_attributes.each do |attr, value|
+        expect(t.send(attr)).to eq(value), enhanced_error.call(attr, value, t.send(attr))
+      end
+    end
+
+    it 'should ghost user_activity_events' do
+      u = FactoryBot.create(:tijuana_user)
+      uae = IdentityTijuana::UserActivityEvent.create!(
+        user: u,
+        activity: 'activity',
+        campaign_id: 1,
+        page_sequence_id: 1,
+        page_id: 1,
+        content_module_id: 1,
+        content_module_type: 'module-type',
+        user_response_id: 1,
+        user_response_type: 'user_response_type',
+        public_stream_html: 'Sensitive PI data',
+        donation_amount_in_cents: 1000,
+        donation_frequency: 'donation_frequency',
+        email_id: 1,
+        push_id: 1,
+        source: 'source',
+        acquisition_source_id: 1,
+      )
+
+      original_attributes = uae.attributes.symbolize_keys
+
+      described_class.new([u.id], 'test-reason').ghost_users
+
+      uae.reload
+
+      nils = [:public_stream_html]
+
+      nils.each do |prop|
+        expect(uae.send(prop)).to eq(nil)
+      end
+
+      unchanged_attributes = original_attributes.except(*nils, :updated_at)
+
+      unchanged_attributes.each do |attr, value|
+        expect(uae.send(attr)).to eq(value), enhanced_error.call(attr, value, uae.send(attr))
+      end
+    end
+
+    it 'should ghost user_emails' do
+      u = FactoryBot.create(:tijuana_user)
+      ue = IdentityTijuana::UserEmail.create!(
+        user: u,
+        content_module_id: 1,
+        subject: 'subject line',
+        body: 'email content with some PI data',
+        from: 'Some PI data',
+        targets: 'targets emails',
+        email_id: 1,
+        page_id: 1,
+        cc_me: true,
+        send_to_target: 'send_to_target',
+        dynamic_attributes: 'Non PI data',
+      )
+
+      original_attributes = ue.attributes.symbolize_keys
+
+      described_class.new([u.id], 'test-reason').ghost_users
+
+      ue.reload
+
+      empties = [:body, :from]
+
+      empties.each do |prop|
+        expect(ue.send(prop)).to eq('')
+      end
+
+      unchanged_attributes = original_attributes.except(*empties, :updated_at)
+
+      unchanged_attributes.each do |attr, value|
+        expect(ue.send(attr)).to eq(value), enhanced_error.call(attr, value, ue.send(attr))
+      end
+    end
+
+    it 'should not ghost users with active recurring donations' do
+      user = FactoryBot.create(:tijuana_user_with_everything)
+      u2 = FactoryBot.create(:tijuana_user_with_everything)
+      FactoryBot.create(
+        :tijuana_donation,
+        user: user,
+        content_module_id: 1,
+        page_id: 1,
+        cover_processing_fee: 1,
+        amount_in_cents: 1000,
+        payment_method: 'credit-card',
+        frequency: 'monthly',
+        make_recurring_at: Time.current,
+        active: true,
+        cancelled_at: nil
+      )
+
+      expect(user.email).not_to include(anon_domain)
+
+      expect(Rails.logger).to receive(:error).with(
+        /Members \[ids: #{user.id}\] with active recurring donations cannot be anonymised!/
+      )
+
+      expect {
+        described_class.new([user.id, u2.id], 'test-reason').ghost_users
+      }.not_to change { user.reload.email }
+    end
+
+    it 'should fail if no member ids are provided for ghosting' do
+      expect(Rails.logger).to receive(:error).with(
+        /No member ids provided to anonymise/
+      )
+
+      described_class.new([], 'test-reason').ghost_users
+    end
+  end
+end

--- a/spec/test_identity_app/app/lib/settings.rb
+++ b/spec/test_identity_app/app/lib/settings.rb
@@ -38,6 +38,12 @@ class Settings
     }
   end
 
+  def self.ghoster
+    return {
+      "email_domain" => "example.com"
+    }
+  end
+
   def self.redis_url
     return ENV['REDIS_URL']
   end

--- a/spec/test_identity_app/db/tijuana_schema.rb
+++ b/spec/test_identity_app/db/tijuana_schema.rb
@@ -39,25 +39,17 @@ ActiveRecord::Schema[7.0].define(version: 0) do
   add_index "agra_actions", ["updated_at"], name: "index_agra_actions_on_updated_at", using: :btree
   add_index "agra_actions", ["user_id"], name: "index_agra_actions_on_user_id", using: :btree
 
-  create_table "automation_events", force: :cascade do |t|
-    t.bigint   "user_id",       limit: 4
-    t.string   "segment",       limit: 255
-    t.string   "campaign_name", limit: 255
-    t.string   "event",         limit: 255
-    t.string   "tag",           limit: 255
-    t.string   "url",           limit: 255
-    t.datetime "received_at"
-    t.datetime "triggered_at"
-    t.datetime "email_sent_at"
-    t.text     "payload",       limit: 65535
-  end
-
-  add_index "automation_events", ["user_id"], name: "index_automation_events_on_user_id", using: :btree
-
-  create_table "automations", force: :cascade do |t|
-    t.string "segment", limit: 255
-    t.string "listId",  limit: 255
-    t.text   "query",   limit: 65535
+  create_table "anonymisation_logs", force: :cascade do |t|
+    t.integer  "user_id",              limit: 4
+    t.integer  "admin_user_id",        limit: 4
+    t.datetime "started_at"
+    t.datetime "finished_at"
+    t.text     "anonymisation_reason", limit: 65535
+    t.text     "status",               limit: 65535
+    t.text     "message",              limit: 65535
+    t.text     "error_stack",          limit: 65535
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
   end
 
   create_table "blasts", force: :cascade do |t|

--- a/spec/test_identity_app/spec/factories/tijuana/call_outcome_factory.rb
+++ b/spec/test_identity_app/spec/factories/tijuana/call_outcome_factory.rb
@@ -1,0 +1,10 @@
+module IdentityTijuana
+  FactoryBot.define do
+    factory :call_outcome, class: CallOutcome do
+      disposition { "No Answer" }
+      campaign_type { "admin_outbound" }
+      campaign_code { "admin" }
+      campaign_name { "Donations Admin" }
+    end
+  end
+end

--- a/spec/test_identity_app/spec/factories/tijuana/donation_factory.rb
+++ b/spec/test_identity_app/spec/factories/tijuana/donation_factory.rb
@@ -1,0 +1,55 @@
+module IdentityTijuana
+  FactoryBot.define do
+    factory(:donation, class: Donation) do |f|
+      f.user              { create(:user) }
+      f.page              { create(:page_with_parent) }
+      f.content_module    { create(:donation_module) }
+      f.amount_in_cents   { 3000 }
+      f.payment_method    { "credit_card" }
+      f.frequency         { "one_off" }
+      f.card_type         { "visa" }
+      f.card_number       { PaymentGateways::CARD_SUCCESS }
+      f.name_on_card      { "Someone Cardholder" }
+      f.card_expiry_year  { Time.now.year }
+      f.card_expiry_month { Time.now.month }
+      f.card_csc          { 123 }
+    end
+
+    factory(:donation_without_validation, :parent => :donation) do |r|
+      r.to_create do |instance|
+        instance.save(:validate => false)
+      end
+    
+    end
+    
+    factory(:recurring_donation, :parent => :donation) do |r|
+      r.frequency      { "weekly" }
+    end
+    
+    factory(:flagged_donation, :parent => :recurring_donation) do |r|
+      r.flagged_since   { Time.now }
+      r.flagged_because { "Y U NO PAY US" }
+    end
+    
+    
+    
+    factory(:paypal_donation, :class => Donation) do |f|
+      f.user              { create(:user) }
+      f.page              { create(:page_with_parent) }
+      f.content_module    { create(:donation_module) }
+      f.amount_in_cents   { 1000 }
+      f.payment_method    { "paypal" }
+      f.frequency         { "one_off" }
+      f.card_type         { nil }
+      f.card_number       { nil }
+      f.name_on_card      { nil }
+      f.card_expiry_year  { nil }
+      f.card_expiry_month { nil }
+      f.card_csc          { nil }
+      f.updated_at        { generate(:time) }
+      f.created_at        { generate(:time) }
+    end
+    
+
+  end
+end

--- a/spec/test_identity_app/spec/factories/tijuana/user.rb
+++ b/spec/test_identity_app/spec/factories/tijuana/user.rb
@@ -26,6 +26,41 @@ module IdentityTijuana
         suburb { Faker::Address.city }
         postcode { IdentityTijuana::Postcode.new(number: Faker::Address.zip_code, state: Faker::Address.state_abbr) }
       end
+
+      factory :tijuana_user_with_everything do
+        home_number { "612#{::Kernel.rand(10_000_000..99_999_999)}" }
+        mobile_number { "614#{::Kernel.rand(10_000_000..99_999_999)}" }
+        street_address { Faker::Address.street_address }
+        suburb { Faker::Address.city }
+        postcode { IdentityTijuana::Postcode.new(number: Faker::Address.zip_code, state: Faker::Address.state_abbr) }
+        country_iso { Faker::Address.country_code }
+        encrypted_password { Faker::Internet.password }
+        password_salt { Faker::Crypto.md5 }
+        reset_password_token { Faker::Crypto.md5 }
+        reset_password_sent_at { 20.days.ago }
+        remember_created_at { 2.hours.ago }
+        current_sign_in_at { 1.hours.ago }
+        current_sign_in_ip { Faker::Internet.ip_v4_address }
+        last_sign_in_at { 10.days.ago }
+        last_sign_in_ip { Faker::Internet.ip_v4_address }
+        random { rand(0.0..0.001) }
+        notes { Faker::Lorem.paragraph }
+        # new_tags { Faker::Lorem.words(number: 5).join(', ') }
+        old_tags { Faker::Lorem.words(number: 5).join(', ') }
+        quick_donate_trigger_id { Faker::Alphanumeric.alphanumeric(number: 12) }
+        facebook_id { Faker::Alphanumeric.alphanumeric(number: 12) }
+        otp_secret_key { Faker::Alphanumeric.alphanumeric(number: 32) }
+        tracking_token { Faker::Alphanumeric.alphanumeric(number: 8) }
+        sign_in_count { rand(10..500) }
+        is_member { 1 }
+        is_admin { 1 }
+        is_volunteer { 1 }
+        is_agra_member { 1 }
+        active { 1 }
+        do_not_call { 0 }
+        do_not_sms { 0 }
+        # fragment { Faker::Lorem.words(number: 5).join(', ') }
+      end
     end
   end
 end


### PR DESCRIPTION
This PR introduces functionality to `sync` ghosted Identity members to Tijuana.

Dependencies

   * This implementation depends on [GetUp/Tijuana#253](https://github.com/GetUp/Tijuana/pull/253).
   * It is required for [the-open/identity#4167](https://github.com/the-open/identity/pull/4167).

For more info see [Asana issue](https://app.asana.com/0/1206874604686569/1207985785302335/f)