### PR TITLE
Temp fix for obtaining changed date for the Id's address records

### DIFF
--- a/app/lib/identity_tijuana/member_sync.rb
+++ b/app/lib/identity_tijuana/member_sync.rb
@@ -91,6 +91,14 @@ module IdentityTijuana
       # Check whether we have an ancillary matching field.
       ancillary_match_value = nil
       case auditable_type
+      when 'Address'
+        # Temporary workaround to retrieve the actual `updated_at` timestamp
+        # of the model, instead of getting it via audit logs.
+        # The reason for this is that we are `touching` member addresses
+        # to `mark` them as primary, and this cannot be picked from the audit
+        # logs as currently it is not a tracked attribute. Thus the change
+        # will be overriden during the `import` sync from TJ.
+        return default_change_date if default_change_date
       when 'PhoneNumber'
         # For phone numbers, need to make sure that changes relate to the
         # correct type of phone number.

--- a/spec/lib/identity_tijuana_member_sync_spec.rb
+++ b/spec/lib/identity_tijuana_member_sync_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe IdentityTijuana::MemberSync do
           ).reorder(created_at: :desc).first
         end
 
-        member.update_address({ town: 'Coburg', postcode: '3021' })
+        member.address.touch! # fake address update
         member.addresses.reload
 
         audit_logs = member.associated_audits.where(
@@ -238,7 +238,7 @@ RSpec.describe IdentityTijuana::MemberSync do
         #   .or(eq(member.updated_at))
         expect(last_audit_log_with_change.audited_changes.key?('line1'))
           .to be(true)
-        expect(audit_logs.count).to eq(4)
+        expect(audit_logs.count).to eq(3)
       end
 
       it 'correctly identifies the change date for email subscription' do

--- a/spec/lib/identity_tijuana_member_sync_spec.rb
+++ b/spec/lib/identity_tijuana_member_sync_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe IdentityTijuana::MemberSync do
         end
 
         member.update_phone_number('61427700333')
+        member.phone_numbers.reload
 
         # NB: we'll only have `2` audits as `update_phone_number`
         # will simply return if the new phone number is same
@@ -166,6 +167,7 @@ RSpec.describe IdentityTijuana::MemberSync do
         end
 
         member.update_phone_number('61291115555')
+        member.phone_numbers.reload
 
         # NB: we'll only have `2` audits as `update_phone_number`
         # will simply return if the new phone number is same
@@ -211,6 +213,7 @@ RSpec.describe IdentityTijuana::MemberSync do
         end
 
         member.update_address({ town: 'Coburg', postcode: '3021' })
+        member.addresses.reload
 
         audit_logs = member.associated_audits.where(
           auditable_type: 'Address',

--- a/spec/lib/identity_tijuana_member_sync_spec.rb
+++ b/spec/lib/identity_tijuana_member_sync_spec.rb
@@ -225,9 +225,17 @@ RSpec.describe IdentityTijuana::MemberSync do
           member.address.updated_at || member.updated_at
         )
 
-        expect(id_change_date).to eq(last_audit_log_with_change.created_at)
-          .or(eq(member.address.updated_at))
-          .or(eq(member.updated_at))
+        # These test modifications are part of the temporary workaround
+        # in `get_id_change_date` for obtaining change timestamp from the
+        # `member.address.updated_at` and not from the audit log.
+        expect(id_change_date).to eq(member.address.updated_at)
+        expect(id_change_date).not_to eq(last_audit_log_with_change.created_at)
+
+        # These are the original assertions and should be reinstated once the
+        # temporary workaround is resolved.
+        # expect(id_change_date).to eq(last_audit_log_with_change.created_at)
+        #   .or(eq(member.address.updated_at))
+        #   .or(eq(member.updated_at))
         expect(last_audit_log_with_change.audited_changes.key?('line1'))
           .to be(true)
         expect(audit_logs.count).to eq(4)

--- a/spec/test_identity_app/app/models/member.rb
+++ b/spec/test_identity_app/app/models/member.rb
@@ -301,7 +301,8 @@ class Member < ApplicationRecord
     }
 
     if (new_address = addresses.find_by(address_attributes))
-      new_address.touch!
+      # Touch it only if it is not a current address
+      new_address.touch! unless new_address.id == old_address_id
     else
       new_address = addresses.create!(address_attributes)
     end


### PR DESCRIPTION
Temporary workaround to obtain Address' changed date changed from the model's `updated_at`, instead of getting it via audit logs.
The reason for this is that we are `touching` member addresses to `mark` them as primary, which cannot be picked from the audit logs as currently it is not a tracked attribute – a change that will be overridden during the `import` sync from TJ.