### PR TITLE
Fix handling of audited_changes for phone_type in get_id_change_date

### DIFF
--- a/app/lib/identity_tijuana/member_sync.rb
+++ b/app/lib/identity_tijuana/member_sync.rb
@@ -134,6 +134,14 @@ module IdentityTijuana
             phone_number_type =
               audit.audited_changes['phone_type'] ||
               PhoneNumber.find_by(id: audit.auditable_id).try(:phone_type)
+
+            # The audited_changes for `phone_type` may contain an array, eg.
+            # ["mobile", "landline"] if the phone type was updated –
+            # and which did happen in the past.
+            # The array represents [old_value, new_value].
+            if audit.action == 'update' && phone_number_type.kind_of?(Array)
+              phone_number_type = phone_number_type[1]
+            end
             next unless phone_number_type.to_sym == ancillary_match_value
           when 'MemberSubscription'
             audit_subscription_id =


### PR DESCRIPTION
This pull request addresses an issue in the `get_id_change_date` method where `audited_changes` for the `phone_type` field may contain an array.

The array format of `audited_changes`, `["old_value", "new_value"]`, was not properly handled when processing phone_type changes leading to errors.