### PR TITLE
Optimise 'donations' and 'taggings' sync – remove FORCE INDEX & eager load 'donation_upgrades'

### DIFF
--- a/lib/identity_tijuana.rb
+++ b/lib/identity_tijuana.rb
@@ -254,7 +254,7 @@ module IdentityTijuana
 
     tags_remaining_behind_sql = %{
       SELECT tu.taggable_id, t.name, tu.id, t.author_id, tu.created_at
-      FROM taggings tu #{'FORCE INDEX (PRIMARY)' unless Settings.tijuana.database_url.start_with? 'postgres'}
+      FROM taggings tu
       JOIN tags t
         ON t.id = tu.tag_id
       WHERE tu.id > #{last_id}
@@ -265,7 +265,7 @@ module IdentityTijuana
 
     scoped_latest_taggings_sql = %{
       SELECT tu.taggable_id, t.name, tu.id, t.author_id, tu.created_at
-      FROM taggings tu #{'FORCE INDEX (PRIMARY)' unless Settings.tijuana.database_url.start_with? 'postgres'}
+      FROM taggings tu
       JOIN tags t
         ON t.id = tu.tag_id
       WHERE tu.id > #{last_id}

--- a/lib/identity_tijuana.rb
+++ b/lib/identity_tijuana.rb
@@ -185,7 +185,7 @@ module IdentityTijuana
                              last_id,
                              users_dependent_data_cutoff
                            )
-                           .includes(:donation)
+                           .includes(donation: :donation_upgrades)
                            .order(:updated_at, :id)
                            .limit(Settings.tijuana.pull_batch_amount || 100)
 


### PR DESCRIPTION
This PR optimises the sync process by optimising the `taggings` query and eager loading `donation_upgardes`.

We are eager loading `donation_upgrades` to avoid N+1 during `donation.import` call.

Additionally, we removed the `FORCE INDEX (PRIMARY)` from the `taggings` query as per below rationale.

The query used `FORCE INDEX (PRIMARY)`, forced using primary index on `tu.id` prevented automatically choosing a better index, resulting in a scan of over `7.8 mil` rows.

Removing the `FORCE INDEX (PRIMARY)` allowed MySQL to choose index automatically, which improved the query reducing the number of scanned rows to just 258.

Sample of slow `taggings` query took ~13 sec to run
```sql
SELECT tu.taggable_id, t.name, tu.id, t.author_id, tu.created_at
      FROM taggings tu FORCE INDEX (PRIMARY)
      JOIN tags t
        ON t.id = tu.tag_id
      WHERE tu.id > 2808072868
        AND taggable_type = 'User'
        AND (tu.created_at < '2025-02-07 06:00:13.148555' OR tu.created_at is null)
        AND t.name like '%_syncid%';
```


```log
EXPLAIN ANALYZE:

-> Nested loop inner join  (cost=2210724.64 rows=45729) (actual time=13562.068..13562.068 rows=0 loops=1)
    -> Filter: ((tu.id > 2808072868) and (tu.taggable_type = 'User') and ((tu.created_at < TIMESTAMP'2025-02-07 06:00:13.148555') or (tu.created_at is null)) and (tu.tag_id is not null))  (cost=2066664.72 rows=411600) (actual time=0.022..7109.955 rows=7845966 loops=1)
        -> Index range scan on tu using PRIMARY over (2808072868 < id)  (cost=2066664.72 rows=10290766) (actual time=0.017..4720.464 rows=7845978 loops=1)
    -> Filter: (t.`name` like '%_syncid%')  (cost=0.25 rows=0.1) (actual time=0.001..0.001 rows=0 loops=7845966)
        -> Single-row index lookup on t using PRIMARY (id=tu.tag_id)  (cost=0.25 rows=1) (actual time=0.000..0.000 rows=1 loops=7845966)
```

Removing the `FORCE INDEX (PRIMARY)` executed in ~100ms

```log
EXPLAIN ANALYZE:

-> Nested loop inner join  (cost=7709.22 rows=258) (actual time=110.303..110.303 rows=0 loops=1)
    -> Filter: (t.`name` like '%_syncid%')  (cost=143.20 rows=157) (actual time=0.306..1.235 rows=21 loops=1)
        -> Table scan on t  (cost=143.20 rows=1417) (actual time=0.047..0.783 rows=1414 loops=1)
    -> Filter: ((tu.created_at < TIMESTAMP'2025-02-07 06:00:13.148555') or (tu.created_at is null))  (cost=39.87 rows=2) (actual time=5.193..5.193 rows=0 loops=21)
        -> Index lookup on tu using taggind_idx (tag_id=t.id), with index condition: ((tu.id > 2808072868) and (tu.taggable_type = 'User'))  (cost=39.87 rows=82) (actual time=5.193..5.193 rows=0 loops=21)
```