### PR TITLE
Export members in batches during sync process

### DIFF
--- a/lib/identity_tijuana.rb
+++ b/lib/identity_tijuana.rb
@@ -106,11 +106,13 @@ module IdentityTijuana
       )
     ).pluck('member_id')
 
-    updated_members = Member.includes(:phone_numbers, :addresses, :member_subscriptions)
-                            .where(id: updated_member_ids)
+    updated_member_ids.each_slice(Settings.tijuana.pull_batch_amount || 100) do |batch_ids|
+      updated_members = Member.includes(:phone_numbers, :addresses, :member_subscriptions)
+                              .where(id: batch_ids)
 
-    updated_members.each do |member|
-      MemberSync.export_member(member, sync_id)
+      updated_members.each do |member|
+        MemberSync.export_member(member, sync_id)
+      end
     end
 
     unless updated_users.empty?


### PR DESCRIPTION
This PR batches the export of modified Id members to Tijuana. 

The non-batch approach performed poorly, ie. was running out of memory, after a substantial change ~500,000 member records in Id.